### PR TITLE
feat: generalizing meta table

### DIFF
--- a/demo/App.jsx
+++ b/demo/App.jsx
@@ -285,10 +285,9 @@ const metaSpec = {
 export default function App() {
     return (
         <GoslingMetaComponent
-            linkedTrack={detailID}
             goslingSpec={goslingSpec}
             metaSpec={metaSpec}
-            alignmentType={{type: "loose"}}
+            alignmentType={{type: "loose", trackID: detailID}}
         />
     );
 }

--- a/demo/App.jsx
+++ b/demo/App.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { GoslingMetaComponent } from '../src/index.ts';
+import {GoslingMetaComponent} from '../src/index.ts';
 
 const islandData = {
     data: {
@@ -8,8 +8,8 @@ const islandData = {
         chromosomeField: 'Accession',
         genomicFields: ['Island start', 'Island end']
     },
-    x: { field: 'Island start', type: 'genomic' },
-    xe: { field: 'Island end', type: 'genomic' }
+    x: {field: 'Island start', type: 'genomic'},
+    xe: {field: 'Island end', type: 'genomic'}
 };
 const detailID = 'detailedView';
 const circularRadius = 200;
@@ -18,7 +18,7 @@ const centerRadius = 0.5;
 const linearHeight = 120;
 const linearSize = linearHeight / 6;
 
-const spec = {
+const goslingSpec = {
     title: 'IslandViewer 4 (Bertelli et al. 2017)',
     subtitle: 'Salmonella enterica subsp. enterica serovar Typhi Ty2, complete genome.',
     description: 'Reimplementation of https://www.pathogenomics.sfu.ca/islandviewer/accession/NC_004631.1/',
@@ -32,12 +32,27 @@ const spec = {
             spacing: 0.1,
             tracks: [
                 {
-                    style: { outlineWidth: 1, outline: 'black' },
+                    data: {
+                        url: 'https://s3.amazonaws.com/gosling-lang.org/data/IslandViewer/NC_004631.1_GCcontent.csv',
+                        type: 'csv',
+                        separator: '\t',
+                        genomicFields: ['Position']
+                    },
+                    y: {field: 'GCcontent', type: 'quantitative', range: [-250, 0], axis: 'none'},
+                    mark: 'line',
+                    size: {value: 0.5},
+                    x: {field: 'Position', type: 'genomic'},
+                    color: {
+                        value: 'black'
+                    }
+                },
+                {
+                    experimental: {mouseEvents: true},
+                    style: {outlineWidth: 1, outline: 'black'},
                     data: {
                         url: 'https://s3.amazonaws.com/gosling-lang.org/data/IslandViewer/NC_004631.1_annotations.csv',
                         type: 'csv',
-                        chromosomeField: 'Accession',
-                        genomicFields: ['Gene start', 'Gene end']
+                        genomicFields: ['Gene start']
                     },
                     dataTransform: [
                         {
@@ -46,16 +61,15 @@ const spec = {
                             boundingBox: {
                                 padding: 3.5,
                                 startField: 'Gene start',
-                                endField: 'Gene end'
+                                endField: 'Gene start'
                             },
                             newField: 'row'
                         }
                     ],
-                    row: { field: 'row', type: 'nominal' },
+                    y: {field: 'row', type: 'nominal', flip: true},
                     mark: 'point',
-                    x: { field: 'Gene start', type: 'genomic' },
-                    xe: { field: 'Gene end', type: 'genomic' },
-                    size: { value: 3 },
+                    x: {field: 'Gene start', type: 'genomic'},
+                    size: {value: 3},
                     color: {
                         field: 'Type',
                         type: 'nominal',
@@ -92,7 +106,7 @@ const spec = {
                 },
                 {
                     mark: 'brush',
-                    x: { linkingId: 'detail' }
+                    x: {linkingId: 'detail'}
                 }
             ],
             width: circularRadius * 2,
@@ -100,7 +114,7 @@ const spec = {
         },
         {
             layout: 'linear',
-            xDomain: { chromosome: 'NC_004631.1', interval: [1000000, 1500000] },
+            xDomain: {chromosome: 'NC_004631.1', interval: [1000000, 1500000]},
             linkingId: 'detail',
             alignment: 'overlay',
             tracks: [
@@ -112,14 +126,14 @@ const spec = {
                         genomicFields: ['Gene start', 'Gene end']
                     },
                     id: detailID,
-                    x: { field: 'Gene start', type: 'genomic' },
-                    xe: { field: 'Gene end', type: 'genomic' },
-                    y: { value: 5.5 * linearSize },
-                    size: { value: linearSize },
+                    x: {field: 'Gene start', type: 'genomic'},
+                    xe: {field: 'Gene end', type: 'genomic'},
+                    y: {value: 5.5 * linearSize},
+                    size: {value: linearSize},
                     mark: 'rect',
-                    dataTransform: [{ type: 'filter', field: 'Strand', oneOf: ['1'] }],
-                    color: { value: '#E9967A' },
-                    tooltip: [{ field: 'Gene name', type: 'nominal', alt: 'Name' }]
+                    dataTransform: [{type: 'filter', field: 'Strand', oneOf: ['1']}],
+                    color: {value: '#E9967A'},
+                    tooltip: [{field: 'Gene name', type: 'nominal', alt: 'Name'}]
                 },
                 {
                     data: {
@@ -128,14 +142,14 @@ const spec = {
                         chromosomeField: 'Accession',
                         genomicFields: ['Gene start', 'Gene end']
                     },
-                    x: { field: 'Gene start', type: 'genomic' },
-                    xe: { field: 'Gene end', type: 'genomic' },
-                    y: { value: 4.5 * linearSize },
-                    size: { value: linearSize },
+                    x: {field: 'Gene start', type: 'genomic'},
+                    xe: {field: 'Gene end', type: 'genomic'},
+                    y: {value: 4.5 * linearSize},
+                    size: {value: linearSize},
                     mark: 'rect',
-                    dataTransform: [{ type: 'filter', field: 'Strand', oneOf: ['-1'] }],
-                    color: { value: '#87976E' },
-                    tooltip: [{ field: 'Gene name', type: 'nominal', alt: 'Name' }]
+                    dataTransform: [{type: 'filter', field: 'Strand', oneOf: ['-1']}],
+                    color: {value: '#87976E'},
+                    tooltip: [{field: 'Gene name', type: 'nominal', alt: 'Name'}]
                 },
                 {
                     data: {
@@ -144,13 +158,13 @@ const spec = {
                         chromosomeField: 'Accession',
                         genomicFields: ['Gene start', 'Gene end']
                     },
-                    x: { field: 'Gene start', type: 'genomic' },
-                    xe: { field: 'Gene end', type: 'genomic' },
-                    y: { value: 5.5 * linearSize },
+                    x: {field: 'Gene start', type: 'genomic'},
+                    xe: {field: 'Gene end', type: 'genomic'},
+                    y: {value: 5.5 * linearSize},
                     mark: 'text',
-                    text: { field: 'Gene name', type: 'nominal' },
-                    dataTransform: [{ type: 'filter', field: 'Strand', oneOf: ['1'] }],
-                    color: { value: '#ffffff' },
+                    text: {field: 'Gene name', type: 'nominal'},
+                    dataTransform: [{type: 'filter', field: 'Strand', oneOf: ['1']}],
+                    color: {value: '#ffffff'},
                     visibility: [
                         {
                             operation: 'less-than',
@@ -168,13 +182,13 @@ const spec = {
                         chromosomeField: 'Accession',
                         genomicFields: ['Gene start', 'Gene end']
                     },
-                    x: { field: 'Gene start', type: 'genomic' },
-                    xe: { field: 'Gene end', type: 'genomic' },
-                    y: { value: 4.5 * linearSize },
+                    x: {field: 'Gene start', type: 'genomic'},
+                    xe: {field: 'Gene end', type: 'genomic'},
+                    y: {value: 4.5 * linearSize},
                     mark: 'text',
-                    text: { field: 'Gene name', type: 'nominal' },
-                    dataTransform: [{ type: 'filter', field: 'Strand', oneOf: ['-1'] }],
-                    color: { value: '#ffffff' },
+                    text: {field: 'Gene name', type: 'nominal'},
+                    dataTransform: [{type: 'filter', field: 'Strand', oneOf: ['-1']}],
+                    color: {value: '#ffffff'},
                     visibility: [
                         {
                             operation: 'less-than',
@@ -188,41 +202,40 @@ const spec = {
                 {
                     ...islandData,
                     mark: 'rect',
-                    dataTransform: [{ type: 'filter', field: 'Method', oneOf: ['IslandPath-DIMOB'] }],
-                    y: { value: 0.5 * linearSize },
-                    size: { value: linearSize },
-                    color: { value: '#4169E1' }
+                    dataTransform: [{type: 'filter', field: 'Method', oneOf: ['IslandPath-DIMOB']}],
+                    y: {value: 0.5 * linearSize},
+                    size: {value: linearSize},
+                    color: {value: '#4169E1'}
                 },
                 {
                     ...islandData,
                     mark: 'rect',
-                    dataTransform: [{ type: 'filter', field: 'Method', oneOf: ['SIGI-HMM'] }],
-                    y: { value: 1.5 * linearSize },
-                    size: { value: linearSize },
-                    color: { value: '#FF8C00' }
+                    dataTransform: [{type: 'filter', field: 'Method', oneOf: ['SIGI-HMM']}],
+                    y: {value: 1.5 * linearSize},
+                    size: {value: linearSize},
+                    color: {value: '#FF8C00'}
                 },
                 {
                     ...islandData,
                     mark: 'rect',
-                    dataTransform: [{ type: 'filter', field: 'Method', oneOf: ['IslandPick'] }],
-                    y: { value: 2.5 * linearSize },
-                    size: { value: linearSize },
-                    color: { value: '#008001' }
+                    dataTransform: [{type: 'filter', field: 'Method', oneOf: ['IslandPick']}],
+                    y: {value: 2.5 * linearSize},
+                    size: {value: linearSize},
+                    color: {value: '#008001'}
                 },
                 {
                     ...islandData,
                     mark: 'rect',
-                    dataTransform: [{ type: 'filter', field: 'Method', oneOf: ['Islander'] }],
-                    y: { value: 3.5 * linearSize },
-                    size: { value: linearSize },
-                    color: { value: '#40E0D0' }
+                    dataTransform: [{type: 'filter', field: 'Method', oneOf: ['Islander']}],
+                    y: {value: 3.5 * linearSize},
+                    size: {value: linearSize},
+                    color: {value: '#40E0D0'}
                 },
                 {
                     data: {
                         url: 'https://s3.amazonaws.com/gosling-lang.org/data/IslandViewer/NC_004631.1_annotations.csv',
                         type: 'csv',
-                        chromosomeField: 'Accession',
-                        genomicFields: ['Gene start', 'Gene end']
+                        genomicFields: ['Gene start']
                     },
                     dataTransform: [
                         {
@@ -231,23 +244,22 @@ const spec = {
                             boundingBox: {
                                 padding: 3.5,
                                 startField: 'Gene start',
-                                endField: 'Gene end'
+                                endField: 'Gene start'
                             },
                             newField: 'row'
                         }
                     ],
-                    row: { field: 'row', type: 'nominal' },
+                    row: {field: 'row', type: 'nominal'},
                     mark: 'point',
-                    x: { field: 'Gene start', type: 'genomic' },
-                    xe: { field: 'Gene end', type: 'genomic' },
-                    size: { value: 3 },
+                    x: {field: 'Gene start', type: 'genomic'},
+                    size: {value: 3},
                     color: {
                         field: 'Type',
                         type: 'nominal',
                         domain: ['Victors', 'BLAST', 'RGI', 'PAG'],
                         range: ['#460B80', '#A684EA', '#FF9CC1', '#FF9CC1']
                     },
-                    tooltip: [{ field: 'Type', type: 'nominal', alt: 'Name' }]
+                    tooltip: [{field: 'Type', type: 'nominal', alt: 'Name'}]
                 }
             ],
             width: circularRadius * 2,
@@ -255,16 +267,28 @@ const spec = {
         }
     ]
 };
+const metaSpec = {
+    type: 'table',
+    dataTransform: [
+        {
+            type: "merge",
+            fields: ["Islands", "Annotations"],
+            mergeChar: "/",
+            newField: "Prediction Method",
+        }
+    ],
+    width: 600,
+    columns: ['Prediction Method', 'Gene name', 'Accnum', 'Product']
+}
 
 export default function App() {
     // Example of using Gosling Meta Component
     return (
         <GoslingMetaComponent
-            goslingSpec={spec}
-            metaSpec={{
-                type: 'table'
-                // ... other props
-            }}
+            dataTracks={[detailID]}
+            goslingSpec={goslingSpec}
+            metaSpec={metaSpec}
+            alignmentType={{type: "loose"}}
         />
     );
 }

--- a/demo/App.jsx
+++ b/demo/App.jsx
@@ -278,14 +278,14 @@ const metaSpec = {
         }
     ],
     width: 600,
+    genomicColumns: ['Gene start', 'Gene end'],
     columns: ['Prediction Method', 'Gene name', 'Accnum', 'Product']
 }
 
 export default function App() {
-    // Example of using Gosling Meta Component
     return (
         <GoslingMetaComponent
-            dataTracks={[detailID]}
+            linkedTrack={detailID}
             goslingSpec={goslingSpec}
             metaSpec={metaSpec}
             alignmentType={{type: "loose"}}

--- a/demo/App.jsx
+++ b/demo/App.jsx
@@ -287,7 +287,7 @@ export default function App() {
         <GoslingMetaComponent
             goslingSpec={goslingSpec}
             metaSpec={metaSpec}
-            alignmentType={{type: "loose", trackID: detailID}}
+            connectionType={{type: "weak", trackId: detailID}}
         />
     );
 }

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
         "start": "vite",
         "build": "vite build",
         "serve": "vite preview",
+        "test": "vitest",
         "predeploy": "yarn build",
         "format": "eslint src/ --fix && prettier --write *",
         "deploy": "touch dist/.nojekyll; gh-pages -d dist -t --git git"
@@ -39,6 +40,6 @@
         "prettier": "^2.8.8",
         "typescript": "*",
         "vite": "^4.3.7",
-        "vitest": "^0.31.1"
+        "vitest": "^0.31.2"
     }
 }

--- a/src/GoslingMetaComponent.tsx
+++ b/src/GoslingMetaComponent.tsx
@@ -1,25 +1,26 @@
 import React, {useRef, useState, useEffect} from 'react';
 import {GoslingComponent, type GoslingRef, type GoslingSpec} from 'gosling.js';
 import {type Datum} from 'gosling.js/dist/src/core/gosling.schema';
-import MetaTable, {MetaTableProps} from './MetaTable';
+import MetaTable, {MetaTableSpec} from './MetaTable';
 import 'higlass/dist/hglib.css';
 import './index.css';
 
 export type MetaSpec = {
     width: number;
     height?: number;
-} & MetaTableProps
+} & MetaTableSpec
 
 interface AlignmentType {
     type: 'loose' | 'tight';
     trackID?: string;
 }
 
+
 interface GoslingMetaComponentProps {
     goslingSpec: GoslingSpec;
     metaSpec: MetaSpec;
-    // tracks that are linked in metaSpec and goslingSpec
-    dataTracks: string[];
+    // track that is linked in metaSpec and goslingSpec
+    linkedTrack: string;
     alignmentType: AlignmentType;
 }
 
@@ -29,7 +30,7 @@ interface GoslingMetaComponentProps {
  * @returns
  */
 export default function GoslingMetaComponent(props: GoslingMetaComponentProps) {
-    const {goslingSpec, metaSpec, dataTracks, alignmentType} = props;
+    const {goslingSpec, metaSpec, linkedTrack, alignmentType} = props;
 
     const gosRef = useRef<GoslingRef>(null);
     const containerRef = useRef<HTMLInputElement>(null);
@@ -39,45 +40,19 @@ export default function GoslingMetaComponent(props: GoslingMetaComponentProps) {
         gosPos = {left: 100 + metaSpec.width, top: 100};
         metaPos = {left: 100, top: 100};
     } else {
-        // TODO get position of track that is used for alignment when alignmentType=="tight"
+        // TODO: get position of track that is used for alignment when alignmentType=="tight" (Related to issue #909)
     }
 
-    const [data, setData] = useState<Datum[]>([]);
-    const [metaHeight, setMetaHeight] = useState(metaSpec.height!==undefined?metaSpec.height:100);
+    const [metaHeight, setMetaHeight] = useState(metaSpec.height !== undefined ? metaSpec.height : 100);
     useEffect(() => {
+        if (containerRef.current == null) return;
         // if the user does not provide a height and the alignmentType is "loose" use the full height of the gosling component
-        if(metaSpec.height===undefined && alignmentType.type==="loose") {
-            if (containerRef.current == null) return;
+        if (metaSpec.height === undefined && alignmentType.type === "loose") {
             setMetaHeight(containerRef.current.clientHeight)
         }
-        // TODO: get height of spec when alignmentType=="tight"
-    }, [])
-    useEffect(() => {
-        if (gosRef.current == null) return;
-        if (metaSpec.type === "table") {
-            // TODO Better: Use a brush event in gosling.js
-            gosRef.current.api.subscribe('rawData', (type, rawdata) => {
-                const range = gosRef.current?.hgApi.api.getLocation(dataTracks[0]).xDomain;
-                // TODO remove 'Accnum' check when rawdata event is adapted
-                if (rawdata.data.length > 0 && dataTracks.includes(rawdata.id) && 'Accnum' in rawdata.data[0]) {
-                    // TODO get genomic coordinates fields from spec
-                    const dataInRange = rawdata.data.filter(
-                        entry =>
-                            (entry['Gene start'] > range[0] && entry['Gene start'] < range[1]) ||
-                            (entry['Gene end'] > range[0] && entry['Gene end'] < range[1])
-                    );
-                    const uniqueInRange = dataInRange.filter(
-                        (v, i, a) => a.findIndex(v2 => v2['Gene name'] === v['Gene name']) === i
-                    );
-                    setData(uniqueInRange);
-                }
-            });
-            return () => {
-                gosRef.current?.api.unsubscribe('rawData');
-            };
-        }
-    }, []);
-    // ...
+        // TODO: get height of spec when alignmentType=="tight" (Related to issue #909)
+    }, [metaSpec.height, alignmentType.type, containerRef.current])
+
 
     return (
         <div>
@@ -86,9 +61,13 @@ export default function GoslingMetaComponent(props: GoslingMetaComponentProps) {
             </div>
             <div id="metavis-component-wrapper" style={{...metaPos}}>
                 {metaSpec.type === 'table' ?
-                    <MetaTable data={data} width={metaSpec.width} height={metaHeight}
-                               dataTransform={metaSpec.dataTransform}
-                               columns={metaSpec.columns} type="table"/> : null}
+                    <MetaTable dataTransform={metaSpec.dataTransform}
+                               gosRef={gosRef}
+                               linkedTrack={linkedTrack}
+                               genomicColumns={metaSpec.genomicColumns}
+                               columns={metaSpec.columns}
+                               width={metaSpec.width}
+                               height={metaHeight}/> : null}
             </div>
         </div>
     );

--- a/src/GoslingMetaComponent.tsx
+++ b/src/GoslingMetaComponent.tsx
@@ -1,6 +1,5 @@
 import React, {useRef, useState, useEffect} from 'react';
 import {GoslingComponent, type GoslingRef, type GoslingSpec} from 'gosling.js';
-import {type Datum} from 'gosling.js/dist/src/core/gosling.schema';
 import MetaTable, {MetaTableSpec} from './MetaTable';
 import 'higlass/dist/hglib.css';
 import './index.css';
@@ -12,15 +11,13 @@ export type MetaSpec = {
 
 interface AlignmentType {
     type: 'loose' | 'tight';
-    trackID?: string;
+    trackID: string;
 }
 
 
 interface GoslingMetaComponentProps {
     goslingSpec: GoslingSpec;
     metaSpec: MetaSpec;
-    // track that is linked in metaSpec and goslingSpec
-    linkedTrack: string;
     alignmentType: AlignmentType;
 }
 
@@ -30,7 +27,7 @@ interface GoslingMetaComponentProps {
  * @returns
  */
 export default function GoslingMetaComponent(props: GoslingMetaComponentProps) {
-    const {goslingSpec, metaSpec, linkedTrack, alignmentType} = props;
+    const {goslingSpec, metaSpec, alignmentType} = props;
 
     const gosRef = useRef<GoslingRef>(null);
     const containerRef = useRef<HTMLInputElement>(null);
@@ -63,7 +60,7 @@ export default function GoslingMetaComponent(props: GoslingMetaComponentProps) {
                 {metaSpec.type === 'table' ?
                     <MetaTable dataTransform={metaSpec.dataTransform}
                                gosRef={gosRef}
-                               linkedTrack={linkedTrack}
+                               linkedTrack={alignmentType.trackID}
                                genomicColumns={metaSpec.genomicColumns}
                                columns={metaSpec.columns}
                                width={metaSpec.width}

--- a/src/GoslingMetaComponent.tsx
+++ b/src/GoslingMetaComponent.tsx
@@ -9,16 +9,16 @@ export type MetaSpec = {
     height?: number;
 } & MetaTableSpec
 
-interface AlignmentType {
-    type: 'loose' | 'tight';
-    trackID: string;
+interface ConnectionType {
+    type: 'weak' | 'strong';
+    trackId: string;
 }
 
 
 interface GoslingMetaComponentProps {
     goslingSpec: GoslingSpec;
     metaSpec: MetaSpec;
-    alignmentType: AlignmentType;
+    connectionType: ConnectionType;
 }
 
 /**
@@ -27,28 +27,28 @@ interface GoslingMetaComponentProps {
  * @returns
  */
 export default function GoslingMetaComponent(props: GoslingMetaComponentProps) {
-    const {goslingSpec, metaSpec, alignmentType} = props;
+    const {goslingSpec, metaSpec, connectionType} = props;
 
     const gosRef = useRef<GoslingRef>(null);
     const containerRef = useRef<HTMLInputElement>(null);
 
     let gosPos, metaPos;
-    if (alignmentType.type == 'loose') {
+    if (connectionType.type == 'weak') {
         gosPos = {left: 100 + metaSpec.width, top: 100};
         metaPos = {left: 100, top: 100};
     } else {
-        // TODO: get position of track that is used for alignment when alignmentType=="tight" (Related to issue #909)
+        // TODO: get position of track that is used for alignment when connectionType=="strong" (Related to issue #909)
     }
 
-    const [metaHeight, setMetaHeight] = useState(metaSpec.height !== undefined ? metaSpec.height : 100);
+    const [metaHeight, setMetaHeight] = useState(metaSpec.height ?? 100);
     useEffect(() => {
         if (containerRef.current == null) return;
         // if the user does not provide a height and the alignmentType is "loose" use the full height of the gosling component
-        if (metaSpec.height === undefined && alignmentType.type === "loose") {
+        if (!metaSpec.height && connectionType.type === "weak") {
             setMetaHeight(containerRef.current.clientHeight)
         }
-        // TODO: get height of spec when alignmentType=="tight" (Related to issue #909)
-    }, [metaSpec.height, alignmentType.type, containerRef.current])
+        // TODO: get height of spec when connectionType=="strong" (Related to issue #909)
+    }, [metaSpec.height, connectionType.type, containerRef.current])
 
 
     return (
@@ -60,7 +60,7 @@ export default function GoslingMetaComponent(props: GoslingMetaComponentProps) {
                 {metaSpec.type === 'table' ?
                     <MetaTable dataTransform={metaSpec.dataTransform}
                                gosRef={gosRef}
-                               linkedTrack={alignmentType.trackID}
+                               linkedTrack={connectionType.trackId}
                                genomicColumns={metaSpec.genomicColumns}
                                columns={metaSpec.columns}
                                width={metaSpec.width}

--- a/src/GoslingMetaComponent.tsx
+++ b/src/GoslingMetaComponent.tsx
@@ -1,72 +1,94 @@
-import React, { useRef, useState, useEffect } from 'react';
-import { GoslingComponent, type GoslingRef, type GoslingSpec } from 'gosling.js';
-import { type Datum } from 'gosling.js/dist/src/core/gosling.schema';
-import MetaTable from './MetaTable';
+import React, {useRef, useState, useEffect} from 'react';
+import {GoslingComponent, type GoslingRef, type GoslingSpec} from 'gosling.js';
+import {type Datum} from 'gosling.js/dist/src/core/gosling.schema';
+import MetaTable, {MetaTableProps} from './MetaTable';
 import 'higlass/dist/hglib.css';
 import './index.css';
 
-interface MetaSpec {
-    type: 'table'; // just an example of a user spec
-    // ...
+export type MetaSpec = {
+    width: number;
+    height?: number;
+} & MetaTableProps
+
+interface AlignmentType {
+    type: 'loose' | 'tight';
+    trackID?: string;
 }
 
 interface GoslingMetaComponentProps {
     goslingSpec: GoslingSpec;
     metaSpec: MetaSpec;
+    // tracks that are linked in metaSpec and goslingSpec
+    dataTracks: string[];
+    alignmentType: AlignmentType;
 }
 
 /**
  * Main component that renders gosling visualization and metadata visualization.
- * @param props 
- * @returns 
+ * @param props
+ * @returns
  */
 export default function GoslingMetaComponent(props: GoslingMetaComponentProps) {
-    const { goslingSpec, metaSpec } = props;
+    const {goslingSpec, metaSpec, dataTracks, alignmentType} = props;
 
     const gosRef = useRef<GoslingRef>(null);
+    const containerRef = useRef<HTMLInputElement>(null);
 
-    // ... need to calculate the position of gosling component and metadata vis
-    const metaVisWidth = 600;
-    const gosPos = { left: 100 + metaVisWidth, top: 100 };
-    const metaPos = { left: 100, top: 100 };
+    let gosPos, metaPos;
+    if (alignmentType.type == 'loose') {
+        gosPos = {left: 100 + metaSpec.width, top: 100};
+        metaPos = {left: 100, top: 100};
+    } else {
+        // TODO get position of track that is used for alignment when alignmentType=="tight"
+    }
 
-    // code copied from the `gosling-react-example`
-    const detailID = 'detailedView';
-    const circularRadius = 200;
-    const centerRadius = 0.5;
-    const linearHeight = 120;
-    const linearSize = linearHeight / 6;
     const [data, setData] = useState<Datum[]>([]);
-
+    const [metaHeight, setMetaHeight] = useState(metaSpec.height!==undefined?metaSpec.height:100);
+    useEffect(() => {
+        // if the user does not provide a height and the alignmentType is "loose" use the full height of the gosling component
+        if(metaSpec.height===undefined && alignmentType.type==="loose") {
+            if (containerRef.current == null) return;
+            setMetaHeight(containerRef.current.clientHeight)
+        }
+        // TODO: get height of spec when alignmentType=="tight"
+    }, [])
     useEffect(() => {
         if (gosRef.current == null) return;
-        gosRef.current.api.subscribe('rawData', (type, rawdata) => {
-            const range = gosRef.current?.hgApi.api.getLocation(detailID).xDomain;
-            if (rawdata.data.length > 0 && rawdata.id === detailID && 'Accnum' in rawdata.data[0]) {
-                const dataInRange = rawdata.data.filter(
-                    entry =>
-                        (entry['Gene start'] > range[0] && entry['Gene start'] < range[1]) ||
-                        (entry['Gene end'] > range[0] && entry['Gene end'] < range[1])
-                );
-                const uniqueInRange = dataInRange.filter(
-                    (v, i, a) => a.findIndex(v2 => v2['Gene name'] === v['Gene name']) === i
-                );
-                setData(uniqueInRange);
-            }
-        });
-        return () => {
-            gosRef.current?.api.unsubscribe('rawData');
-        };
-    }, [gosRef]);
+        if (metaSpec.type === "table") {
+            // TODO Better: Use a brush event in gosling.js
+            gosRef.current.api.subscribe('rawData', (type, rawdata) => {
+                const range = gosRef.current?.hgApi.api.getLocation(dataTracks[0]).xDomain;
+                // TODO remove 'Accnum' check when rawdata event is adapted
+                if (rawdata.data.length > 0 && dataTracks.includes(rawdata.id) && 'Accnum' in rawdata.data[0]) {
+                    // TODO get genomic coordinates fields from spec
+                    const dataInRange = rawdata.data.filter(
+                        entry =>
+                            (entry['Gene start'] > range[0] && entry['Gene start'] < range[1]) ||
+                            (entry['Gene end'] > range[0] && entry['Gene end'] < range[1])
+                    );
+                    const uniqueInRange = dataInRange.filter(
+                        (v, i, a) => a.findIndex(v2 => v2['Gene name'] === v['Gene name']) === i
+                    );
+                    setData(uniqueInRange);
+                }
+            });
+            return () => {
+                gosRef.current?.api.unsubscribe('rawData');
+            };
+        }
+    }, []);
     // ...
 
     return (
         <div>
-            <div id="gosling-component-wrapper" style={{ ...gosPos }}>
-                <GoslingComponent ref={gosRef} spec={goslingSpec} padding={0} />
+            <div id="gosling-component-wrapper" style={{...gosPos}} ref={containerRef}>
+                <GoslingComponent ref={gosRef} spec={goslingSpec} padding={0}/>
             </div>
-            <div id="metavis-component-wrapper" style={{ ...metaPos }}>
-                {metaSpec.type === 'table' ? <MetaTable data={data} width={metaVisWidth} height={646} /> : null}
+            <div id="metavis-component-wrapper" style={{...metaPos}}>
+                {metaSpec.type === 'table' ?
+                    <MetaTable data={data} width={metaSpec.width} height={metaHeight}
+                               dataTransform={metaSpec.dataTransform}
+                               columns={metaSpec.columns} type="table"/> : null}
             </div>
         </div>
     );

--- a/src/MetaTable.tsx
+++ b/src/MetaTable.tsx
@@ -34,7 +34,6 @@ export interface MergeColumnsTransform {
     newField: string;
 }
 
-
 export interface RenameColumnsTransform {
     type: 'rename',
     fields: string[];

--- a/src/MetaTable.tsx
+++ b/src/MetaTable.tsx
@@ -9,16 +9,13 @@ export type MetaTableSpec = {
     data?: DataDeep;
     dataTransform: tableDataTransform[];
     genomicColumns: [string,string] | [string];
-    columns: string[];
+    columns?: string[];
 }
 
-interface MetaTableProps {
+interface MetaTableProps extends Omit<MetaTableSpec, 'type' | 'data'> {
     data?: Datum[];
-    dataTransform: tableDataTransform[];
     gosRef: React.RefObject<GoslingRef>;
     linkedTrack: string;
-    genomicColumns: [string,string] | [string];
-    columns?: string[];
     width: number | string;
     height: number | string;
 }

--- a/src/MetaTable.tsx
+++ b/src/MetaTable.tsx
@@ -1,17 +1,29 @@
-import React from 'react';
+import React, {useEffect, useState} from 'react';
 import {mergeData, renameColumns} from "./table-data-transform";
-import {Datum} from "gosling.js/dist/src/core/gosling.schema";
+import {DataDeep, Datum} from "gosling.js/dist/src/core/gosling.schema";
+import {GoslingRef} from "gosling.js";
 
-export interface MetaTableProps {
+export type MetaTableSpec = {
     type: "table",
-    data: Datum[]; // this type seems to be incorrect
-    dataTransform: dataTransform[];
+    // TODO: allow custom data specification for metatable
+    data?: DataDeep;
+    dataTransform: tableDataTransform[];
+    genomicColumns: [string,string] | [string];
     columns: string[];
+}
+
+interface MetaTableProps {
+    data?: Datum[];
+    dataTransform: tableDataTransform[];
+    gosRef: React.RefObject<GoslingRef>;
+    linkedTrack: string;
+    genomicColumns: [string,string] | [string];
+    columns?: string[];
     width: number | string;
     height: number | string;
 }
 
-type dataTransform =
+export type tableDataTransform =
     | MergeColumnsTransform
     | RenameColumnsTransform;
 
@@ -31,37 +43,74 @@ export interface RenameColumnsTransform {
 
 
 export default function MetaTable(props: MetaTableProps) {
-    const {data, dataTransform, columns, width, height} = props;
-    let dataTransformed = Array.from(data);
-    dataTransform.forEach(transform => {
-        switch (transform.type) {
-            case("merge"):
-                dataTransformed = mergeData(transform, data);
-                break;
-            case("rename"):
-                dataTransformed = renameColumns(transform, data);
-                break;
-        }
-    })
-    // ...
-    const tableKeys = columns.length > 0 ? columns : dataTransformed.length > 0 ? Object.keys(dataTransformed[0]) : [];
-    // ...
+    const { dataTransform, gosRef, linkedTrack, genomicColumns, columns, width, height} = props;
+    const [dataInRange, setDataInRange] = useState<Datum[]>([]);
+    const [columnNames, setColumnNames]=useState<string[]>([])
+    useEffect(() => {
+        if (gosRef.current == null) return;
+        // TODO Better: Use a brush event in gosling.js (related issue: #910)
+        gosRef.current.api.subscribe('rawData', (type, rawdata) => {
+            if(rawdata.data.length > 0) {
+                let dataTransformed: Datum[] = Array.from(rawdata.data);
+                dataTransform.forEach(transform => {
+                    switch (transform.type) {
+                        case("merge"):
+                            dataTransformed = mergeData(transform, rawdata.data);
+                            break;
+                        case("rename"):
+                            dataTransformed = renameColumns(transform, rawdata.data);
+                            break;
+                    }
+                })
+                const tableKeys = columns && columns.length > 0 ? columns : dataTransformed.length > 0 ? Object.keys(dataTransformed[0]) : [];
+                setColumnNames(tableKeys);
+                const range = gosRef.current?.hgApi.api.getLocation(linkedTrack).xDomain;
+                // TODO remove column check when rawdata event is adapted (related issues: #909, #894)
+                if (linkedTrack === rawdata.id && tableKeys.every((col) => Object.keys(rawdata.data[0]).includes(col))) {
+                    let dataInRange: Datum[] = [];
+                    // features have start and end
+                    if (genomicColumns.length === 2) {
+                        const start = genomicColumns[0];
+                        const end = genomicColumns[1];
+                        dataInRange = rawdata.data.filter(
+                            entry =>
+                                (entry[start] > range[0] && entry[start] < range[1]) ||
+                                (entry[end] > range[0] && entry[end] < range[1])
+                        );
+                        // features have only start (point features)
+                    } else {
+                        const position = genomicColumns[0];
+                        dataInRange = rawdata.data.filter(
+                            entry => entry[position] > range[0] && entry[position] < range[1]
+                        );
+                    }
+                    const uniqueInRange = dataInRange.filter(
+                        (v, i, a) => a.findIndex(v2 => v2['Gene name'] === v['Gene name']) === i
+                    );
+                    setDataInRange(uniqueInRange);
+                }
+            }
+        });
+        return () => {
+            gosRef.current?.api.unsubscribe('rawData');
+        };
+    }, []);
 
     return (
         <>
-            {data.length === 0 ? null : (
+            {dataInRange.length === 0 ? null : (
                 <div
                     style={{
                         height,
                         overflowY: 'scroll',
                         display: 'inline-block',
-                        width: Number(width)-10,
+                        width: Number(width) - 10,
                     }}
                 >
                     <table className="table-fixed border-collapse border border-slate-400">
                         <thead className="capitalize">
                         <tr className="border border-slate-300  bg-slate-100">
-                            {tableKeys.map(d => (
+                            {columnNames.map(d => (
                                 <th className="px-1" key={d}>
                                     {d}
                                 </th>
@@ -69,9 +118,9 @@ export default function MetaTable(props: MetaTableProps) {
                         </tr>
                         </thead>
                         <tbody>
-                        {dataTransformed.map(d => (
+                        {dataInRange.map(d => (
                             <tr className="border border-slate-300" key={d['Gene name']}>
-                                {tableKeys.map(key => {
+                                {columnNames.map(key => {
                                     return (
                                         <td className="px-1" key={key}>
                                             {d[key]}

--- a/src/MetaTable.tsx
+++ b/src/MetaTable.tsx
@@ -1,16 +1,50 @@
 import React from 'react';
+import {mergeData, renameColumns} from "./table-data-transform";
+import {Datum} from "gosling.js/dist/src/core/gosling.schema";
 
-interface MetaTableProps {
-    data: Array<Array<Record<string, string | number>>>; // this type seems to be incorrect
+export interface MetaTableProps {
+    type: "table",
+    data: Datum[]; // this type seems to be incorrect
+    dataTransform: dataTransform[];
+    columns: string[];
     width: number | string;
     height: number | string;
 }
 
-export default function MetaTable(props: MetaTableProps) {
-    const { data, width, height } = props;
+type dataTransform =
+    | MergeColumnsTransform
+    | RenameColumnsTransform;
 
+export interface MergeColumnsTransform {
+    type: 'merge';
+    fields: string[];
+    mergeChar: string;
+    newField: string;
+}
+
+
+export interface RenameColumnsTransform {
+    type: 'rename',
+    fields: string[];
+    newFields: string[];
+}
+
+
+export default function MetaTable(props: MetaTableProps) {
+    const {data, dataTransform, columns, width, height} = props;
+    let dataTransformed = Array.from(data);
+    dataTransform.forEach(transform => {
+        switch (transform.type) {
+            case("merge"):
+                dataTransformed = mergeData(transform, data);
+                break;
+            case("rename"):
+                dataTransformed = renameColumns(transform, data);
+                break;
+        }
+    })
     // ...
-    const tableKeys = ['Prediction Method', 'Gene name', 'Accnum', 'Product'];
+    const tableKeys = columns.length > 0 ? columns : dataTransformed.length > 0 ? Object.keys(dataTransformed[0]) : [];
     // ...
 
     return (
@@ -21,45 +55,31 @@ export default function MetaTable(props: MetaTableProps) {
                         height,
                         overflowY: 'scroll',
                         display: 'inline-block',
-                        width
+                        width: Number(width)-10,
                     }}
                 >
                     <table className="table-fixed border-collapse border border-slate-400">
                         <thead className="capitalize">
-                            <tr className="border border-slate-300  bg-slate-100">
-                                {tableKeys.map(d => (
-                                    <th className="px-1" key={d}>
-                                        {d}
-                                    </th>
-                                ))}
-                            </tr>
+                        <tr className="border border-slate-300  bg-slate-100">
+                            {tableKeys.map(d => (
+                                <th className="px-1" key={d}>
+                                    {d}
+                                </th>
+                            ))}
+                        </tr>
                         </thead>
                         <tbody>
-                            {data.map(d => (
-                                <tr className="border border-slate-300" key={d['Gene name']}>
-                                    {tableKeys.map(key => {
-                                        let value = '';
-                                        if (key === 'Prediction Method') {
-                                            if (d.Islands.length > 0) {
-                                                if (d.Annotations.length > 0) {
-                                                    value = d.Islands + '/' + d.Annotations;
-                                                } else {
-                                                    value = d.Islands;
-                                                }
-                                            } else if (d.Annotations.length > 0) {
-                                                value = d.Annotations;
-                                            }
-                                        } else {
-                                            value = d[key];
-                                        }
-                                        return (
-                                            <td className="px-1" key={key}>
-                                                {value}
-                                            </td>
-                                        );
-                                    })}
-                                </tr>
-                            ))}
+                        {dataTransformed.map(d => (
+                            <tr className="border border-slate-300" key={d['Gene name']}>
+                                {tableKeys.map(key => {
+                                    return (
+                                        <td className="px-1" key={key}>
+                                            {d[key]}
+                                        </td>
+                                    );
+                                })}
+                            </tr>
+                        ))}
                         </tbody>
                     </table>
                 </div>

--- a/src/table-data-transform.test.ts
+++ b/src/table-data-transform.test.ts
@@ -1,0 +1,76 @@
+import {mergeData, renameColumns} from "./table-data-transform";
+
+
+describe('Table Data Transformation', () => {
+    it('Merge', () => {
+        const merged = mergeData({type: 'merge', fields: ['a', 'b'], mergeChar: '/', newField: 'd'}, [
+            {a: 'a', b: 1, c: 'c'},
+            {a: 'b', b: '1', c: 'd'},
+            {a: 'a', b: 3, c: 'c'},
+            {a: 'b', b: 4, c: 'a'},
+            {a: 'b', b: '4', c: 'c'}
+        ]);
+        expect(merged).toMatchInlineSnapshot(`
+          [
+            {
+              "c": "c",
+              "d": "a/1",
+            },
+            {
+              "c": "d",
+              "d": "b/1",
+            },
+            {
+              "c": "c",
+              "d": "a/3",
+            },
+            {
+              "c": "a",
+              "d": "b/4",
+            },
+            {
+              "c": "c",
+              "d": "b/4",
+            },
+          ]
+        `);
+    });
+    it('Rename', () => {
+        const renamed = renameColumns({type: 'rename', fields: ['a', 'b'], newFields: ['d', 'e']}, [
+            {a: 'a', b: 1, c: 'c'},
+            {a: 'b', b: '1', c: 'd'},
+            {a: 'a', b: 3, c: 'c'},
+            {a: 'b', b: 4, c: 'a'},
+            {a: 'b', b: '4', c: 'c'}
+        ]);
+        expect(renamed).toMatchInlineSnapshot(`
+          [
+            {
+              "c": "c",
+              "d": "a",
+              "e": 1,
+            },
+            {
+              "c": "d",
+              "d": "b",
+              "e": "1",
+            },
+            {
+              "c": "c",
+              "d": "a",
+              "e": 3,
+            },
+            {
+              "c": "a",
+              "d": "b",
+              "e": 4,
+            },
+            {
+              "c": "c",
+              "d": "b",
+              "e": "4",
+            },
+          ]
+        `);
+    });
+});

--- a/src/table-data-transform.ts
+++ b/src/table-data-transform.ts
@@ -10,10 +10,16 @@ import {Datum} from "gosling.js/dist/src/core/gosling.schema";
  */
 export function mergeData(transform: MergeColumnsTransform, data: Datum[]) {
     const {fields, mergeChar, newField} = transform;
-    const output = Array.from(data);
-    output.forEach(d => {
+    const output = data.map(d => {
+        const returnObj: Datum = {};
         const values = fields.map(f => d[f]).filter(v => v !== "" && v !== undefined && v !== null);
-        d[newField] = values.length>0?values.reduce((a, v) => a + mergeChar + v):"";
+        returnObj[newField] = values.length>0?values.reduce((a, v) => a + mergeChar + v):"";
+        Object.keys(d).forEach(key=>{
+            if(!transform.fields.includes(key)){
+                returnObj[key]=d[key]
+            }
+        })
+        return(returnObj);
     })
     return (output);
 }
@@ -22,7 +28,7 @@ export function mergeData(transform: MergeColumnsTransform, data: Datum[]) {
 export function renameColumns(transform: RenameColumnsTransform, data: Datum[]) {
     const {fields, newFields} = transform;
     const output: Datum[] = data.map(d => {
-        const returnObj = {};
+        const returnObj:Datum = {};
         Object.keys(d).forEach(key => {
             const fieldIndex = fields.indexOf(key);
             if (fieldIndex === -1) {

--- a/src/table-data-transform.ts
+++ b/src/table-data-transform.ts
@@ -1,0 +1,38 @@
+import type * as d3 from 'd3';
+import type {
+    MergeColumnsTransform, RenameColumnsTransform
+} from './MetaTable';
+import {Datum} from "gosling.js/dist/src/core/gosling.schema";
+
+
+/**
+ * Apply filter
+ */
+export function mergeData(transform: MergeColumnsTransform, data: Datum[]) {
+    const {fields, mergeChar, newField} = transform;
+    const output = Array.from(data);
+    output.forEach(d => {
+        const values = fields.map(f => d[f]).filter(v => v !== "" && v !== undefined && v !== null);
+        d[newField] = values.length>0?values.reduce((a, v) => a + mergeChar + v):"";
+    })
+    return (output);
+}
+
+
+export function renameColumns(transform: RenameColumnsTransform, data: Datum[]) {
+    const {fields, newFields} = transform;
+    const output: Datum[] = data.map(d => {
+        const returnObj = {};
+        Object.keys(d).forEach(key => {
+            const fieldIndex = fields.indexOf(key);
+            if (fieldIndex === -1) {
+                returnObj[key] = d[key]
+            } else {
+                returnObj[newFields[fieldIndex]] = d[key]
+            }
+        })
+        return (returnObj)
+    })
+    return (output);
+}
+

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,7 +14,8 @@
         "strictNullChecks": true,
         "isolatedModules": false,
         "noEmit": true,
-        "jsx": "react"
+        "jsx": "react",
+        "types": ["vitest/globals"]
     },
     "include": ["./src", "./demo"],
     "exclude": ["node_modules"]

--- a/vite.config.js
+++ b/vite.config.js
@@ -3,5 +3,8 @@ import reactRefresh from '@vitejs/plugin-react';
 
 export default defineConfig({
     build: { target: 'esnext' },
-    plugins: [reactRefresh()]
+    plugins: [reactRefresh()],
+    test: {
+        globals: true
+  },
 });


### PR DESCRIPTION
I generalized the IslandViewer Example. The biggest issue I see right now is the connection of the gosling component and the metadata component in MetaTable.tsx because of some things that I'd like to implement in the gosling API
- Instead of a rawData event it would make more sense to have a brush/rangeSelect event. The current solution only allows showing the table if there is a detailed view with the same data.
- I would like to also allow separately loading data sets for the metadata table

Features I want to add in future PRs:
- Make table sortable and stylable
- Add functionality to add simple visualizations in table